### PR TITLE
Use OpenMP parallel-for during layout step

### DIFF
--- a/compile-demo
+++ b/compile-demo
@@ -1,2 +1,2 @@
 #!/bin/sh
-g++ -O3 -std=c++11 ./demo/gcc/main.cpp ./src/layout.cpp ./src/quadTree.cpp -o layout++
+g++ -O3 -fopenmp -std=c++11 ./demo/gcc/main.cpp ./src/layout.cpp ./src/quadTree.cpp -o layout++

--- a/compile-demo
+++ b/compile-demo
@@ -1,2 +1,2 @@
 #!/bin/sh
-g++ -O3 -fopenmp -std=c++11 ./demo/gcc/main.cpp ./src/layout.cpp ./src/quadTree.cpp -o layout++
+g++ -O3 -fopenmp -Wall -std=c++11 ./demo/gcc/main.cpp ./src/layout.cpp ./src/quadTree.cpp -o layout++

--- a/demo/gcc/main.cpp
+++ b/demo/gcc/main.cpp
@@ -11,10 +11,10 @@ using namespace std;
 
 void save(int i, std::vector<Body> *bodies) {
     std::stringstream ss;
-    
+
     ss << i << ".bin";
     std::ofstream outfile (ss.str(), std::ofstream::binary);
-    
+
     char block[3 * 4];
     int *triplet = (int *)&block;
     for (vector<Body>::iterator body = bodies->begin() ; body != bodies->end(); ++body) {
@@ -82,10 +82,10 @@ int main(int argc, const char * argv[]) {
     const char * graphFileName = argv[1];
     cout << argv[0] << endl;
     srand(42);
-    
+
     cout << "Loading links from " << graphFileName << "... " << endl;
     FileContent graphFile = readFile(graphFileName);
-    
+
     Layout graphLayout;
     int startFrom = 0;
     if (argc < 3) {
@@ -102,8 +102,8 @@ int main(int argc, const char * argv[]) {
         cout << "Loaded " << graphLayout.getBodiesCount() << " bodies;" << endl;
     }
     cout << "Starting layout from " << startFrom << " iteration;" << endl;
-    
-    for (int i = startFrom; i < 10000; ++i) {
+
+    for (int i = startFrom; i <= 10000; ++i) {
         cout << "Step " << i << endl;
         bool done = graphLayout.step();
         if (done) {
@@ -114,6 +114,6 @@ int main(int argc, const char * argv[]) {
             save(i, graphLayout.getBodies());
         }
     }
-    
+
     delete[] graphFile.content;
 }

--- a/demo/gcc/main.cpp
+++ b/demo/gcc/main.cpp
@@ -27,10 +27,10 @@ void save(int i, std::vector<Body> *bodies) {
     outfile.close();
 }
 
-typedef struct {
+struct FileContent {
     int *content;
-    long size;
-} FileContent;
+    size_t size;
+};
 
 FileContent readFile(const char *fileName) {
     streampos size;

--- a/src/layout.h
+++ b/src/layout.h
@@ -33,7 +33,7 @@ class Layout {
   
 public:
   Layout();
-  void init(int *links, long linksSize, int *initialPositions, long posSize);
+  void init(int *links, long linksSize, int *initialPositions, size_t posSize);
   void init(int *links, long size);
   bool step();
   size_t getBodiesCount();

--- a/src/quadTree.cpp
+++ b/src/quadTree.cpp
@@ -155,7 +155,7 @@ void QuadTree::insertBodies(std::vector<Body> &bodies) {
       root->body = &bodies[0];
     }
 
-    for (int i = 1; i < bodies.size(); ++i) {
+    for (size_t i = 1; i < bodies.size(); ++i) {
       insert(&(bodies[i]), root);
     }
     return;
@@ -169,7 +169,7 @@ void QuadTree::updateBodyForce(Body *sourceBody) {
   std::vector<QuadTreeNode *> queue;
   int queueLength = 1;
   int shiftIndex = 0;
-  int pushIndex = 0;
+  size_t pushIndex = 0;
   double v, dx, dy, dz, r;
   double fx = 0, fy = 0, fz = 0;
   queue.push_back(root);

--- a/src/quadTree.h
+++ b/src/quadTree.h
@@ -24,7 +24,7 @@ struct QuadTreeNode {
   double bottom;
   double front;
   double back;
-  
+ 
   void reset() {
     quads[0] = quads[1] = quads[2] = quads[3] = quads[4] = quads[5] = quads[6] = quads[7] = NULL;
     body = NULL;
@@ -35,13 +35,13 @@ struct QuadTreeNode {
 };
 
 class NodePool {
-  int currentAvailable = 0;
+  size_t currentAvailable = 0;
   std::vector<QuadTreeNode *> pool;
 public:
   void reset() {
     currentAvailable = 0;
   }
-  
+
   QuadTreeNode* get() {
     QuadTreeNode *result;
     if (currentAvailable < pool.size()) {


### PR DESCRIPTION
On a intel i7-4790k (4 physical cores) with a test set of ~1M objects, I get ~3.5x speedup.
On a dual E5-2643 (8 physical cores), I get ~5x speedup.

There is still a significant single-threaded portion, I suspect it is the insertion into the quad tree. I haven't checked, but I'm not sure it's concurrent-ready...

EDIT: Running `gprof` on a sample run shows that indeed, 10% of the time is spent in `QuadTree::insert` (82% is spent in `QuadTree::updateBodyForce`, and 4% in `Layout::updateSpringForce`).
