### PR TITLE
Fixes clang-omp installation instructions

### DIFF
--- a/compile-demo
+++ b/compile-demo
@@ -1,6 +1,7 @@
 #!/bin/sh
 # If you are compiling this on OSX make sure to install omp:
-# brew install clang-omp
+#     brew install llvm
+#     ln -s /usr/local/opt/llvm/bin/clang++ /usr/local/bin/clang-omp++
 # and use this line:
 # clang-omp++ -O3 -fopenmp -Wall -std=c++11 -I./src ./demo/ngraph.native.demo/ngraph.native.demo/main.cpp ./src/layout.cpp ./src/quadTree.cpp -o layout++
 g++ -O3 -fopenmp -Wall -std=c++11 -I./src ./demo/gcc/main.cpp ./src/layout.cpp ./src/quadTree.cpp -o layout++


### PR DESCRIPTION
`clang-omp` had been boneyarded, however `llvm` has build in support for OpenMP
- https://github.com/Homebrew/legacy-homebrew/issues/50686
- https://stackoverflow.com/questions/38971394/brew-install-clang-omp-not-working